### PR TITLE
Add FastAPI backend and Tauri frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
 # Repeat
+
+## Project Description
+
+Repeat is an alternative to Anki, designed to be a native macOS application with a Python backend. The app is built using Tauri and features a modern UI implemented with shadcn UI components. The main purpose of Repeat is to help users create, manage, and review flashcards efficiently.
+
+## Main Features
+
+- Native macOS application
+- Python backend using Flask
+- Modern UI with shadcn UI components
+- Create, manage, and review flashcards
+- Sync flashcards with the backend
+
+## Development Environment Setup
+
+### Prerequisites
+
+- Python 3.8 or higher
+- Node.js 14 or higher
+- npm or yarn
+- Tauri CLI
+
+### Backend Setup
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/5uru/Repeat.git
+   cd Repeat/backend
+   ```
+
+2. Create a virtual environment and activate it:
+   ```sh
+   python -m venv venv
+   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+   ```
+
+3. Install the required dependencies:
+   ```sh
+   pip install -r requirements.txt
+   ```
+
+4. Run the Flask app:
+   ```sh
+   flask run
+   ```
+
+### Frontend Setup
+
+1. Navigate to the frontend directory:
+   ```sh
+   cd ../frontend
+   ```
+
+2. Install the required dependencies:
+   ```sh
+   npm install
+   ```
+
+3. Run the Tauri app:
+   ```sh
+   npm run tauri dev
+   ```
+
+## Building and Running the App
+
+### Backend
+
+1. Ensure the virtual environment is activated:
+   ```sh
+   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+   ```
+
+2. Run the Flask app:
+   ```sh
+   flask run
+   ```
+
+### Frontend
+
+1. Navigate to the frontend directory:
+   ```sh
+   cd frontend
+   ```
+
+2. Build the Tauri app:
+   ```sh
+   npm run tauri build
+   ```
+
+3. Run the built app:
+   ```sh
+   ./src-tauri/target/release/bundle/macos/Repeat.app
+   ```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI()
+
+class Flashcard(BaseModel):
+    id: int
+    question: str
+    answer: str
+
+flashcards = []
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to Repeat"}
+
+@app.get("/flashcards", response_model=List[Flashcard])
+def get_flashcards():
+    return flashcards
+
+@app.post("/flashcards", response_model=Flashcard)
+def create_flashcard(flashcard: Flashcard):
+    flashcards.append(flashcard)
+    return flashcard

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "repeat",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "tauri": "tauri",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^1.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "4.0.3",
+    "shadcn-ui": "^1.0.0",
+    "axios": "^0.21.1"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1.0.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "../frontend",
+    "distDir": "../frontend/dist"
+  },
+  "package": {
+    "productName": "Repeat",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "category": "Education",
+      "identifier": "com.5uru.repeat",
+      "icon": [
+        "icons/icon.icns"
+      ],
+      "targets": [
+        "dmg"
+      ]
+    },
+    "windows": [
+      {
+        "title": "Repeat",
+        "width": 800,
+        "height": 600
+      }
+    ],
+    "security": {
+      "csp": null
+    },
+    "updater": {
+      "active": false
+    }
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+import { Button, Card, Input } from 'shadcn-ui';
+import axios from 'axios';
+
+const App = () => {
+  const [flashcards, setFlashcards] = useState([]);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+
+  useEffect(() => {
+    fetchFlashcards();
+  }, []);
+
+  const fetchFlashcards = async () => {
+    try {
+      const response = await axios.get('http://localhost:5000/flashcards');
+      setFlashcards(response.data);
+    } catch (error) {
+      console.error('Error fetching flashcards:', error);
+    }
+  };
+
+  const createFlashcard = async () => {
+    try {
+      const response = await axios.post('http://localhost:5000/flashcards', {
+        question,
+        answer,
+      });
+      setFlashcards([...flashcards, response.data.data]);
+      setQuestion('');
+      setAnswer('');
+    } catch (error) {
+      console.error('Error creating flashcard:', error);
+    }
+  };
+
+  return (
+    <div className="app">
+      <h1>Repeat</h1>
+      <div className="flashcard-form">
+        <Input
+          placeholder="Question"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+        />
+        <Input
+          placeholder="Answer"
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+        />
+        <Button onClick={createFlashcard}>Create Flashcard</Button>
+      </div>
+      <div className="flashcards">
+        {flashcards.map((flashcard) => (
+          <Card key={flashcard.id}>
+            <p>Question: {flashcard.question}</p>
+            <p>Answer: {flashcard.answer}</p>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default App;


### PR DESCRIPTION
Add initial implementation of Repeat app with Python backend and Tauri frontend.

* **Backend:**
  - Create `backend/app.py` with a basic FastAPI app.
  - Implement routes to handle flashcard data.

* **Frontend:**
  - Add `frontend/src-tauri/tauri.conf.json` for Tauri configuration.
  - Create `frontend/src/App.tsx` with a React component for the main app.
  - Implement UI using shadcn UI components.
  - Add functionality to interact with the Python backend.

* **Project Setup:**
  - Update `README.md` with project description, features, and setup instructions.
  - Add `frontend/package.json` with dependencies for Tauri, React, and shadcn UI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/5uru/Repeat?shareId=20b09856-7f99-4aef-ba2a-88d3959b4871).